### PR TITLE
Fix: Ensure unpacked data is an array before using array_key_exists()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,10 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true
+        }
     },
     "extra": {
         "branch-alias": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -70,7 +70,7 @@ class Client
                 throw new RecvFailedException('Recv failed');
             }
 
-            return with($packer->unpack($ret), function ($data) {
+            return with((array) $packer->unpack($ret), function ($data) {
                 if (array_key_exists('result', $data)) {
                     return $data['result'];
                 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -70,16 +70,12 @@ class Client
                 throw new RecvFailedException('Recv failed');
             }
 
-            return with($packer->unpack($ret), function ($data) use ($ret) {
-                if (! is_array($data)) {
-                    throw new RecvFailedException('Recv failed, invalid data: ' . $ret);
-                }
-
+            return with((array) $packer->unpack($ret), function ($data) use ($ret) {
                 if (array_key_exists('result', $data)) {
                     return $data['result'];
                 }
 
-                throw new ServerException($data['error'] ?? []);
+                throw new ServerException($data['error'] ?? ['code' => 0, 'message' => 'Recv failed, invalid data: ' . $ret]);
             });
         };
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -70,7 +70,11 @@ class Client
                 throw new RecvFailedException('Recv failed');
             }
 
-            return with((array) $packer->unpack($ret), function ($data) {
+            return with((array) $packer->unpack($ret), function ($data) use ($ret) {
+                if (! is_array($data)) {
+                    throw new RecvFailedException('Recv failed, invalid data: ' . $ret);
+                }
+
                 if (array_key_exists('result', $data)) {
                     return $data['result'];
                 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -70,7 +70,7 @@ class Client
                 throw new RecvFailedException('Recv failed');
             }
 
-            return with((array) $packer->unpack($ret), function ($data) use ($ret) {
+            return with($packer->unpack($ret), function ($data) use ($ret) {
                 if (! is_array($data)) {
                     throw new RecvFailedException('Recv failed, invalid data: ' . $ret);
                 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -75,7 +75,7 @@ class Client
                     return $data['result'];
                 }
 
-                throw new ServerException($data['error'] ?? ['code' => 0, 'message' => 'Recv failed, invalid data: ' . $ret]);
+                throw new ServerException($data['error'] ?? ['code' => 0, 'message' => 'Invalid data: ' . $ret]);
             });
         };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Safer handling of malformed or unexpected JSON-RPC responses to prevent silent failures.
  - Improved error messages now include the raw response to aid troubleshooting.
  - Normal successful responses continue to return results without behavior changes.

- Chores
  - Composer configuration updated to allow a package-normalization plugin for build/tooling consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->